### PR TITLE
Fix Vite base path and load React entry script

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,6 @@
   </head>
   <body>
     <div id="app"></div>
-
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: '',
+  base: '/',
   build: {
     outDir: 'dist'
   }


### PR DESCRIPTION
## Summary
- load React by adding module script tag in index.html
- set Vite base path to root so assets resolve correctly

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6895c6c46dbc8321b79813c751985ca9